### PR TITLE
Improve burner wallet UX, auto-connect behavior, and game win flow visuals

### DIFF
--- a/packages/nextjs/app/game/[id]/_components/PlayerComponent.tsx
+++ b/packages/nextjs/app/game/[id]/_components/PlayerComponent.tsx
@@ -90,7 +90,16 @@ export const PlayerComponent = ({ game, token, address }: PlayerComponentProps) 
     let pk;
 
     if (rolled && rolledResult.length > 0 && game?.hiddenPrivateKey) {
-      pk = `0x${rolledResult.join("")}${game?.hiddenPrivateKey.replaceAll("*", "")}` as `0x{string}`;
+      const visibleSuffix = game.hiddenPrivateKey.replaceAll("*", "");
+      const prefix = rolledResult.join("");
+      const combined = `${prefix}${visibleSuffix}`;
+
+      // Safety guard: private key must be exactly 32 bytes (64 hex chars).
+      if (combined.length !== 64) {
+        return;
+      }
+
+      pk = `0x${combined}` as `0x{string}`;
       const account = privateKeyToAccount(pk);
       isHiddenChars = account.address == game?.adminAddress;
     }
@@ -166,6 +175,12 @@ export const PlayerComponent = ({ game, token, address }: PlayerComponentProps) 
   return (
     <div className="w-full">
       <div className="flex flex-col items-center mt-6">
+        {game.status === "paused" && (
+          <div className="mb-3 inline-flex items-center gap-2 rounded-full border border-warning/50 bg-warning/10 px-4 py-1 text-[10px] md:text-xs font-semibold uppercase tracking-[0.22em] text-warning">
+            <span className="h-2 w-2 rounded-full bg-warning animate-pulse" />
+            <span>Game paused by host</span>
+          </div>
+        )}
         <button
           className="btn btn-primary px-10"
           onClick={() => {
@@ -206,6 +221,8 @@ export const PlayerComponent = ({ game, token, address }: PlayerComponentProps) 
 
               return (
                 <Image
+                  // index is fine; dice order is stable within a roll
+                  // eslint-disable-next-line react/no-array-index-key
                   key={index}
                   className="transition duration-500 ease-in rounded-lg"
                   src={src}

--- a/packages/nextjs/app/game/[id]/page.tsx
+++ b/packages/nextjs/app/game/[id]/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState, useCallback } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { useAccount, useBalance } from "wagmi";
+import { ArrowPathIcon } from "@heroicons/react/24/outline";
 import { notification } from "~~/utils/scaffold-eth";
 import useGameData from "~~/hooks/useGameData";
 import { useChannel } from "ably/react";
@@ -164,14 +165,11 @@ function GamePage() {
                   Private Key Heist
                 </span>
               </h1>
-              <p className="text-xs md:text-sm text-base-content/60">
-                Mode: <span className="font-semibold uppercase">{game.mode}</span> · Players:{" "}
-                <span className="font-semibold">{game.players.length}</span>
-              </p>
-            </div>
-
-            <div className="mt-2 md:mt-0">
-              <div className="relative rounded-3xl bg-gradient-to-r from-primary/40 via-secondary/70 to-accent/50 border border-primary/40 shadow-glow-primary px-6 py-4 md:px-8 md:py-5 text-center">
+              <div className="flex items-center gap-3 text-xs md:text-sm text-base-content/60">
+                <p className="m-0">
+                  Mode: <span className="font-semibold uppercase">{game.mode}</span> · Players:{" "}
+                  <span className="font-semibold">{game.players.length}</span>
+                </p>
                 <button
                   type="button"
                   onClick={async () => {
@@ -185,10 +183,21 @@ function GamePage() {
                       setIsSyncing(false);
                     }
                   }}
-                  className="absolute left-6 top-3 btn btn-xs btn-outline btn-ghost border-primary/40 text-xs normal-case"
+                  className="btn btn-ghost btn-xs tooltip tooltip-bottom border border-base-300/60 hover:border-primary/60"
+                  data-tip={isSyncing ? "Refreshing..." : "Re-sync game state"}
+                  disabled={isSyncing}
                 >
-                  {isSyncing ? "Syncing..." : "Re-sync"}
+                  {isSyncing ? (
+                    <span className="loading loading-spinner loading-xs" />
+                  ) : (
+                    <ArrowPathIcon className="h-4 w-4" />
+                  )}
                 </button>
+              </div>
+            </div>
+
+            <div className="mt-2 md:mt-0">
+              <div className="relative rounded-3xl bg-gradient-to-r from-primary/40 via-secondary/70 to-accent/50 border border-primary/40 shadow-glow-primary px-6 py-4 md:px-8 md:py-5 text-center">
                 <div className="absolute -top-2 right-6">
                   <span className="inline-flex items-center rounded-full bg-base-100/80 px-3 py-0.5 text-[10px] md:text-xs font-semibold uppercase tracking-[0.18em] text-base-content/70">
                     Prize pool
@@ -216,7 +225,9 @@ function GamePage() {
               )}
               {!isAdmin && !isPlayer && wasKicked && membershipResolved && (
                 <div className="flex flex-1 items-center justify-center bg-base-200/80 px-6 py-16 text-center">
-                  <p className="text-xl md:text-2xl font-semibold text-base-content/80">You have been kicked from this game.</p>
+                  <p className="text-xl md:text-2xl font-semibold text-base-content/80">
+                    You have been kicked from this game.
+                  </p>
                 </div>
               )}
             </div>

--- a/packages/nextjs/components/ScaffoldEthAppWithProviders.tsx
+++ b/packages/nextjs/components/ScaffoldEthAppWithProviders.tsx
@@ -5,7 +5,7 @@ import { RainbowKitProvider, darkTheme } from "@rainbow-me/rainbowkit";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { AppProgressBar as ProgressBar } from "next-nprogress-bar";
 import { Toaster } from "react-hot-toast";
-import { WagmiProvider } from "wagmi";
+import { WagmiProvider, useAccount, useConnect } from "wagmi";
 import { Footer } from "~~/components/Footer";
 import { Header } from "~~/components/Header";
 import { BlockieAvatar } from "~~/components/scaffold-eth";
@@ -34,6 +34,21 @@ export const queryClient = new QueryClient({
   },
 });
 
+const BurnerAutoConnector = () => {
+  const { isConnected } = useAccount();
+  const { connectors, connect, status } = useConnect();
+
+  useEffect(() => {
+    if (isConnected || status === "pending") return;
+    const burner = connectors.find(connector => connector.name.toLowerCase().includes("burner"));
+    if (burner) {
+      connect({ connector: burner });
+    }
+  }, [connect, connectors, isConnected, status]);
+
+  return null;
+};
+
 export const ScaffoldEthAppWithProviders = ({ children }: { children: React.ReactNode }) => {
   const [mounted, setMounted] = useState(false);
 
@@ -44,6 +59,7 @@ export const ScaffoldEthAppWithProviders = ({ children }: { children: React.Reac
   return (
     <WagmiProvider config={wagmiConfig}>
       <QueryClientProvider client={queryClient}>
+        <BurnerAutoConnector />
         {mounted && <ProgressBar height="3px" color="#2299dd" />}
         <RainbowKitProvider avatar={BlockieAvatar} theme={darkTheme()}>
           <ScaffoldEthApp>{children}</ScaffoldEthApp>

--- a/packages/nextjs/components/dicedemo/HostAnnouncement.tsx
+++ b/packages/nextjs/components/dicedemo/HostAnnouncement.tsx
@@ -1,11 +1,14 @@
 import { Dispatch, SetStateAction } from "react";
+import { SparklesIcon } from "@heroicons/react/24/outline";
 import { Address } from "../scaffold-eth";
 import { Game } from "@prisma/client";
+
+const CONFETTI_COLORS = ["#34d399", "#60a5fa", "#f97316", "#facc15", "#a855f7"];
+const CONFETTI_PIECES = 70;
 
 const HostAnnouncement = ({
   isOpen,
   setIsOpen,
-
   game,
 }: {
   isOpen: boolean;
@@ -17,15 +20,48 @@ const HostAnnouncement = ({
   };
 
   return (
-    <div className=" overflow-hidden w-fit text-xl bg-base-200 h-full">
+    <div className="overflow-hidden w-fit text-xl bg-base-200 h-full">
       {isOpen && (
-        <div className="fixed inset-0 flex items-center justify-center bg-opacity-50 z-20">
-          <div className="modal-box md:h-[30%] flex flex-col items-center">
-            <label onClick={closePopup} className="btn btn-sm btn-circle absolute right-2 top-2">
-              ✕
-            </label>
-            <p className="text-center">The Winner is</p>
-            <Address address={game.winner as string} format="long" />
+        <div className="fixed inset-0 z-20 bg-base-300/40 backdrop-blur-sm">
+          {/* Full-screen confetti layer */}
+          <div className="pointer-events-none absolute inset-0 overflow-hidden">
+            {Array.from({ length: CONFETTI_PIECES }).map((_, index) => (
+              // index is fine here; this list is static for the lifetime of the modal
+              // eslint-disable-next-line react/no-array-index-key
+              <span
+                key={index}
+                className="confetti-piece"
+                style={{
+                  left: `${(index / CONFETTI_PIECES) * 100}%`,
+                  backgroundColor: CONFETTI_COLORS[index % CONFETTI_COLORS.length],
+                  animationDelay: `${(index % 10) * 0.12}s`,
+                }}
+              />
+            ))}
+          </div>
+
+          <div className="relative z-10 flex h-full w-full items-center justify-center">
+            <div className="modal-box relative flex max-w-lg flex-col items-center gap-4 text-center">
+              <label onClick={closePopup} className="btn btn-sm btn-circle absolute right-2 top-2 z-10">
+                ✕
+              </label>
+
+              <div className="flex flex-col items-center gap-3">
+                <div className="inline-flex items-center gap-2 rounded-full bg-base-100/80 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-accent">
+                  <SparklesIcon className="h-4 w-4" />
+                  <span>Game finished</span>
+                </div>
+                <h2 className="bg-gradient-to-r from-emerald-300 via-sky-300 to-indigo-300 bg-clip-text text-2xl font-bold text-transparent md:text-3xl">
+                  The heist has a winner
+                </h2>
+                <p className="text-sm text-base-content/70 md:text-base">
+                  Prize claimed by:
+                </p>
+                <div className="rounded-xl bg-base-200/70 px-4 py-2">
+                  <Address address={game.winner as string} format="long" />
+                </div>
+              </div>
+            </div>
           </div>
         </div>
       )}

--- a/packages/nextjs/components/dicedemo/PlayerAnnoucement.tsx
+++ b/packages/nextjs/components/dicedemo/PlayerAnnoucement.tsx
@@ -1,6 +1,10 @@
 import { Dispatch, SetStateAction } from "react";
+import { SparklesIcon } from "@heroicons/react/24/outline";
 import { Game } from "@prisma/client";
 import { loadBurnerSK } from "~~/hooks/scaffold-eth/useBurnerWallet";
+
+const CONFETTI_COLORS = ["#34d399", "#60a5fa", "#f97316", "#facc15", "#a855f7"];
+const CONFETTI_PIECES = 70;
 
 const PlayerAnnouncement = ({
   isOpen,
@@ -27,37 +31,67 @@ const PlayerAnnouncement = ({
   const pwlink = "https://punkwallet.io/opt:pk#" + privateKey;
 
   return (
-    <div className=" overflow-hidden w-fit text-lg bg-base-200 h-full">
+    <div className="overflow-hidden w-fit text-lg bg-base-200 h-full">
       {isOpen && (
-        <div className="fixed inset-0 flex items-center justify-center bg-opacity-50 z-20">
-          <div className="modal-box md:h-[30%] flex flex-col items-center py-4 pt-6">
-            <label onClick={closePopup} className="btn btn-sm btn-circle absolute right-2 top-2">
-              ✕
-            </label>
+        <div className="fixed inset-0 z-20 bg-base-300/40 backdrop-blur-sm">
+          {/* Full-screen confetti for winner */}
+          {isWinner && (
+            <div className="pointer-events-none absolute inset-0 overflow-hidden">
+              {Array.from({ length: CONFETTI_PIECES }).map((_, index) => (
+                // index is fine here; this list is static for the lifetime of the modal
+                // eslint-disable-next-line react/no-array-index-key
+                <span
+                  key={index}
+                  className="confetti-piece"
+                  style={{
+                    left: `${(index / CONFETTI_PIECES) * 100}%`,
+                    backgroundColor: CONFETTI_COLORS[index % CONFETTI_COLORS.length],
+                    animationDelay: `${(index % 10) * 0.12}s`,
+                  }}
+                />
+              ))}
+            </div>
+          )}
 
-            {isWinner && (
-              <div>
-                <p className="text-center">
-                  Congrats, you found the hidden characters and have successfully swept the private Key
-                </p>
-                <p className="text-center">
-                  <a className="font-bold italic text-xl" href={pwlink} target="_blank" rel="noreferrer">
-                    <button className="btn btn-primary"> Open in punk wallet</button>
+          <div className="relative z-10 flex h-full w-full items-center justify-center">
+            <div className="modal-box relative flex max-w-lg flex-col items-center py-4 pt-6 text-center">
+              <label onClick={closePopup} className="btn btn-sm btn-circle absolute right-2 top-2 z-10">
+                ✕
+              </label>
+
+              {isWinner && (
+                <div className="flex flex-col items-center gap-4">
+                  <div className="inline-flex items-center gap-2 rounded-full bg-base-100/80 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-accent">
+                    <SparklesIcon className="h-4 w-4" />
+                    <span>You won the heist</span>
+                  </div>
+                  <p className="max-w-md text-sm text-base-content/80 md:text-base">
+                    Congrats, you found the hidden characters and have successfully swept the private key.
+                  </p>
+                  <a className="font-semibold italic text-base md:text-lg" href={pwlink} target="_blank" rel="noreferrer">
+                    <button className="btn btn-primary">Open in Punk Wallet</button>
                   </a>
+                </div>
+              )}
+
+              {!isWinner && isHacked && !game.winner && (
+                <p className="mt-2 max-w-md text-center text-sm text-base-content/80 md:text-base">
+                  Hidden characters found, {isSweeping ? "trying to sweep private key..." : sweepMessage}
                 </p>
-              </div>
-            )}
-            {!isWinner && isHacked && !game.winner && (
-              <p className="text-center">
-                Hidden characters found, {isSweeping ? "Trying to sweep private key..." : sweepMessage}
-              </p>
-            )}
-            {!isWinner && isHacked && game.winner != undefined && (
-              <p className="text-center">
-                Hidden characters were discovered, but another wallet beat you to claiming the private key.{" "}
-              </p>
-            )}
-            {!isWinner && !isHacked && <div>Someone else found the private key!</div>}
+              )}
+
+              {!isWinner && isHacked && game.winner != undefined && (
+                <p className="mt-2 max-w-md text-center text-sm text-base-content/80 md:text-base">
+                  Hidden characters were discovered, but another wallet beat you to claiming the private key.
+                </p>
+              )}
+
+              {!isWinner && !isHacked && (
+                <div className="mt-2 max-w-md text-center text-sm text-base-content/80 md:text-base">
+                  Someone else discovered the hidden characters and claimed the private key.
+                </div>
+              )}
+            </div>
           </div>
         </div>
       )}

--- a/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton/AddressInfoDropdown.tsx
+++ b/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton/AddressInfoDropdown.tsx
@@ -3,7 +3,6 @@ import { NetworkOptions } from "./NetworkOptions";
 import CopyToClipboard from "react-copy-to-clipboard";
 import { getAddress } from "viem";
 import { Address } from "viem";
-import { useDisconnect } from "wagmi";
 import {
   ArrowLeftOnRectangleIcon,
   ArrowTopRightOnSquareIcon,
@@ -32,7 +31,6 @@ export const AddressInfoDropdown = ({
   displayName,
   blockExplorerAddressLink,
 }: AddressInfoDropdownProps) => {
-  const { disconnect } = useDisconnect();
   const checkSumAddress = getAddress(address);
 
   const [addressCopied, setAddressCopied] = useState(false);
@@ -121,15 +119,6 @@ export const AddressInfoDropdown = ({
               </button>
             </li>
           ) : null}
-          <li className={selectingNetwork ? "hidden" : ""}>
-            <button
-              className="menu-item text-error btn-sm !rounded-xl flex gap-3 py-3"
-              type="button"
-              onClick={() => disconnect()}
-            >
-              <ArrowLeftOnRectangleIcon className="h-6 w-4 ml-2 sm:ml-0" /> <span>Disconnect</span>
-            </button>
-          </li>
         </ul>
       </details>
     </>

--- a/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton/index.tsx
+++ b/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton/index.tsx
@@ -29,12 +29,9 @@ export const RainbowKitCustomConnectButton = () => {
         return (
           <>
             {(() => {
+              // Hide the connect button entirely; rely on burner auto-connect instead.
               if (!connected) {
-                return (
-                  <button className="btn btn-primary btn-sm" onClick={openConnectModal} type="button">
-                    Connect Wallet
-                  </button>
-                );
+                return null;
               }
 
               if (chain.unsupported || chain.id !== targetNetwork.id) {

--- a/packages/nextjs/services/web3/wagmiBurnerOnlyConnectors.tsx
+++ b/packages/nextjs/services/web3/wagmiBurnerOnlyConnectors.tsx
@@ -1,0 +1,21 @@
+import { connectorsForWallets } from "@rainbow-me/rainbowkit";
+import { rainbowkitBurnerWallet } from "burner-connector";
+
+/**
+ * wagmi connectors restricted to Burner Wallet only.
+ */
+export const wagmiBurnerOnlyConnectors = connectorsForWallets(
+  [
+    {
+      groupName: "Burner Wallet",
+      wallets: [rainbowkitBurnerWallet],
+    },
+  ],
+  {
+    appName: "scaffold-eth-2",
+    // A projectId is still required by RainbowKit types even if we don't use WalletConnect.
+    projectId: "burner-only",
+  },
+);
+
+

--- a/packages/nextjs/services/web3/wagmiConfig.tsx
+++ b/packages/nextjs/services/web3/wagmiConfig.tsx
@@ -1,4 +1,4 @@
-import { wagmiConnectors } from "./wagmiConnectors";
+import { wagmiBurnerOnlyConnectors } from "./wagmiBurnerOnlyConnectors";
 import { Chain, createClient, fallback, http } from "viem";
 import { hardhat, mainnet } from "viem/chains";
 import { createConfig } from "wagmi";
@@ -14,7 +14,7 @@ export const enabledChains = targetNetworks.find((network: Chain) => network.id 
 
 export const wagmiConfig = createConfig({
   chains: enabledChains,
-  connectors: wagmiConnectors,
+  connectors: wagmiBurnerOnlyConnectors,
   ssr: true,
   client({ chain }) {
     let rpcFallbacks = [http()];

--- a/packages/nextjs/styles/globals.css
+++ b/packages/nextjs/styles/globals.css
@@ -30,3 +30,67 @@ p {
 .btn.btn-ghost {
   @apply shadow-none;
 }
+
+@keyframes confetti-fall {
+  0% {
+    transform: translate3d(0, -100%, 0) rotateZ(0deg);
+    opacity: 0;
+  }
+  10% {
+    opacity: 1;
+  }
+  100% {
+    transform: translate3d(0, 110vh, 0) rotateZ(360deg);
+    opacity: 0;
+  }
+}
+
+.confetti-piece {
+  position: absolute;
+  width: 8px;
+  height: 16px;
+  border-radius: 2px;
+  opacity: 0;
+  animation-name: confetti-fall;
+  animation-duration: 2.6s;
+  animation-timing-function: linear;
+  animation-iteration-count: infinite;
+}
+
+@keyframes dice-roll-wobble {
+  0% {
+    transform: translateY(0) rotate(0deg);
+  }
+  25% {
+    transform: translateY(-6px) rotate(-6deg);
+  }
+  50% {
+    transform: translateY(0) rotate(4deg);
+  }
+  75% {
+    transform: translateY(-4px) rotate(-4deg);
+  }
+  100% {
+    transform: translateY(0) rotate(0deg);
+  }
+}
+
+.dice-tile {
+  @apply flex items-center justify-center rounded-lg border border-base-300/60 bg-base-100/80 text-base-content shadow-md;
+  min-width: 2.75rem;
+  min-height: 2.75rem;
+  font-size: 1.1rem;
+  font-weight: 700;
+}
+
+@media (min-width: 768px) {
+  .dice-tile {
+    min-width: 3.2rem;
+    min-height: 3.2rem;
+    font-size: 1.3rem;
+  }
+}
+
+.dice-tile-rolling {
+  animation: dice-roll-wobble 0.45s ease-in-out infinite;
+}

--- a/packages/nextjs/utils/diceDemo/gameUtils.ts
+++ b/packages/nextjs/utils/diceDemo/gameUtils.ts
@@ -1,6 +1,7 @@
 export const calculateLength = (count: number) => {
   const maxLength = 120;
-  const calculatedLength = Math.max(maxLength - (count - 1) * 3, 10);
+  // Keep dice comfortably visible even with many hidden characters.
+  const calculatedLength = Math.max(maxLength - (count - 1) * 3, 40);
   return calculatedLength;
 };
 


### PR DESCRIPTION
### What this PR does
* Burner auto-connect & connectors
  - Adds a BurnerAutoConnector to automatically connect the burner wallet on load.
  - Switches wagmi to use burner-only connectors via wagmiBurnerOnlyConnectors.
  - Hides the manual “Connect Wallet” button and removes the disconnect action in the address dropdown.
  
* Wallet & private key UX
  - Safely reads the burner private key from localStorage only in the browser and guards when mismatched with the connected address.
  - Adds a clear security warning, masked/unmasked toggle, and improved copy buttons for the private key.
  - Polishes the PunkWallet link card and QR flow, plus a clearer “Known burner keys” section.
  
* Game UI / winner flow
  - Adds full-screen confetti and upgraded winner/hacked modals for host and players.
  - Improves game header layout with a better re-sync button (icon, tooltip, spinner).
  - Shows a “Game paused by host” banner and tweaks dice layout sizing for better visibility.